### PR TITLE
UC8 Zoeken producten

### DIFF
--- a/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
@@ -15,14 +15,22 @@ namespace Grocery.App.ViewModels
         private readonly IGroceryListItemsService _groceryListItemsService;
         private readonly IProductService _productService;
         private readonly IFileSaverService _fileSaverService;
-        
+
         public ObservableCollection<GroceryListItem> MyGroceryListItems { get; set; } = [];
         public ObservableCollection<Product> AvailableProducts { get; set; } = [];
+        public ObservableCollection<Product> FilteredProducts { get; set; } = [];
 
         [ObservableProperty]
         GroceryList groceryList = new(0, "None", DateOnly.MinValue, "", 0);
+
         [ObservableProperty]
-        string myMessage;
+        string myMessage = "";
+
+        [ObservableProperty]
+        string searchText = "";
+
+        [ObservableProperty]
+        string emptyViewText = "Er zijn geen producten meer om toe te voegen";
 
         public GroceryListItemsViewModel(IGroceryListItemsService groceryListItemsService, IProductService productService, IFileSaverService fileSaverService)
         {
@@ -43,8 +51,50 @@ namespace Grocery.App.ViewModels
         {
             AvailableProducts.Clear();
             foreach (Product p in _productService.GetAll())
-                if (MyGroceryListItems.FirstOrDefault(g => g.ProductId == p.Id) == null  && p.Stock > 0)
+                if (MyGroceryListItems.FirstOrDefault(g => g.ProductId == p.Id) == null && p.Stock > 0)
                     AvailableProducts.Add(p);
+
+            FilterProducts();
+        }
+
+        [RelayCommand]
+        public void SearchProducts(string searchTerm)
+        {
+            SearchText = searchTerm ?? "";
+            FilterProducts();
+        }
+
+        private void FilterProducts()
+        {
+            FilteredProducts.Clear();
+
+            if (string.IsNullOrWhiteSpace(SearchText))
+            {
+                foreach (var product in AvailableProducts)
+                {
+                    FilteredProducts.Add(product);
+                }
+                EmptyViewText = "Er zijn geen producten meer om toe te voegen";
+            }
+            else
+            {
+                var filtered = AvailableProducts.Where(p =>
+                    p.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList();
+
+                foreach (var product in filtered)
+                {
+                    FilteredProducts.Add(product);
+                }
+
+                EmptyViewText = filtered.Count == 0 ?
+                    $"Geen producten gevonden voor '{SearchText}'" :
+                    "Er zijn geen producten meer om toe te voegen";
+            }
+        }
+
+        partial void OnSearchTextChanged(string value)
+        {
+            FilterProducts();
         }
 
         partial void OnGroceryListChanged(GroceryList value)
@@ -58,6 +108,7 @@ namespace Grocery.App.ViewModels
             Dictionary<string, object> paramater = new() { { nameof(GroceryList), GroceryList } };
             await Shell.Current.GoToAsync($"{nameof(ChangeColorView)}?Name={GroceryList.Name}", true, paramater);
         }
+
         [RelayCommand]
         public void AddProduct(Product product)
         {
@@ -66,7 +117,10 @@ namespace Grocery.App.ViewModels
             _groceryListItemsService.Add(item);
             product.Stock--;
             _productService.Update(product);
+
             AvailableProducts.Remove(product);
+            FilteredProducts.Remove(product);
+
             OnGroceryListChanged(GroceryList);
         }
 
@@ -85,6 +139,5 @@ namespace Grocery.App.ViewModels
                 await Toast.Make($"Opslaan mislukt: {ex.Message}").Show(cancellationToken);
             }
         }
-
     }
 }

--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -11,7 +11,7 @@
         <ToolbarItem Text="Wijzig kleur" Command="{Binding ChangeColorCommand}" IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
         <ToolbarItem Text="Deel boodschappenlijst" Command="{Binding ShareGroceryListCommand}" IconImageSource="{FontImage Glyph='&#xf30c;', Color=Black, Size=22}" />
     </ContentPage.ToolbarItems>
-    
+
     <Shell.TitleView>
         <Grid>
             <Label Text="{Binding GroceryList.Name}" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
@@ -54,7 +54,14 @@
 
         <Border Grid.Row="1" Grid.Column="1" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5" HorizontalOptions="Center">
             <StackLayout>
-                <CollectionView ItemsSource="{Binding AvailableProducts}" Margin="5" WidthRequest="300" HorizontalOptions="Start"
+                <SearchBar 
+                    Placeholder="Zoek producten..." 
+                    Text="{Binding SearchText}"
+                    SearchCommand="{Binding SearchProductsCommand}"
+                    SearchCommandParameter="{Binding Source={RelativeSource Self}, Path=Text}"
+                    Margin="5"/>
+
+                <CollectionView ItemsSource="{Binding FilteredProducts}" Margin="5" WidthRequest="300" HorizontalOptions="Start"
                     SelectionMode="Single"
                     SelectionChangedCommand="{Binding AddProductCommand}"
                     SelectionChangedCommandParameter="{Binding Source={RelativeSource Self}, Path=SelectedItem}">
@@ -76,7 +83,7 @@
                     <CollectionView.EmptyView>
                         <ContentView>
                             <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center">
-                                <Label Text="Er zijn geen producten meer om toe te voegen" FontAttributes="Bold" HorizontalTextAlignment="Center"/>
+                                <Label Text="{Binding EmptyViewText}" FontAttributes="Bold" HorizontalTextAlignment="Center"/>
                             </VerticalStackLayout>
                         </ContentView>
                     </CollectionView.EmptyView>

--- a/TestCore/TestProductSearch.cs
+++ b/TestCore/TestProductSearch.cs
@@ -1,0 +1,110 @@
+﻿using Grocery.Core.Models;
+
+namespace TestCore
+{
+    public class TestSearchProducts
+    {
+        private List<Product> testProducts;
+
+        [SetUp]
+        public void Setup()
+        {
+            testProducts = new List<Product>
+            {
+                new Product(1, "Melk", 300),
+                new Product(2, "Kaas", 100),
+                new Product(3, "Brood", 400),
+                new Product(4, "Cornflakes", 0)
+            };
+        }
+
+        // Happy path tests
+        [Test]
+        public void SearchProducts_WithValidSearchTerm_FiltersCorrectly()
+        {
+            // Arrange
+            string searchTerm = "Melk";
+
+            // Act
+            var filteredProducts = FilterProducts(testProducts, searchTerm);
+
+            // Assert
+            Assert.That(filteredProducts.Count, Is.EqualTo(1));
+            Assert.That(filteredProducts[0].Name, Is.EqualTo("Melk"));
+        }
+
+        [TestCase("melk", "Melk")]
+        [TestCase("MELK", "Melk")]
+        [TestCase("kaas", "Kaas")]
+        public void SearchProducts_WithDifferentCasing_FiltersCorrectly(string searchTerm, string expectedProduct)
+        {
+            // Act
+            var filteredProducts = FilterProducts(testProducts, searchTerm);
+
+            // Assert
+            Assert.That(filteredProducts.Count, Is.EqualTo(1));
+            Assert.That(filteredProducts[0].Name, Is.EqualTo(expectedProduct));
+        }
+
+        [Test]
+        public void SearchProducts_WithEmptyString_ShowsAllProductsWithStock()
+        {
+            // Act
+            var filteredProducts = FilterProducts(testProducts, "");
+
+            // Assert
+            Assert.That(filteredProducts.Count, Is.EqualTo(3));
+            Assert.That(filteredProducts.Any(p => p.Name == "Cornflakes"), Is.False);
+        }
+
+        // Unhappy path tests
+        [Test]
+        public void SearchProducts_WithNonExistentProduct_ShowsNoResults()
+        {
+            // Arrange
+            string nonExistentProduct = "xyz123";
+
+            // Act
+            var filteredProducts = FilterProducts(testProducts, nonExistentProduct);
+
+            // Assert
+            Assert.That(filteredProducts.Count, Is.EqualTo(0));
+        }
+
+        [TestCase("")]
+        [TestCase("   ")]
+        public void SearchProducts_WithEmptyOrWhitespace_ShowsProductsWithStock(string searchTerm)
+        {
+            // Act
+            var filteredProducts = FilterProducts(testProducts, searchTerm);
+
+            // Assert
+            Assert.That(filteredProducts.Count, Is.EqualTo(3));
+            Assert.That(filteredProducts.All(p => p.Stock > 0), Is.True);
+        }
+
+        [Test]
+        public void FilterProducts_ExcludesProductsWithZeroStock()
+        {
+            // Act
+            var filteredProducts = FilterProducts(testProducts, "");
+
+            // Assert
+            Assert.That(filteredProducts.Any(p => p.Stock == 0), Is.False);
+        }
+
+        // Helper methode die de filtering van ViewModel simuleert
+        private List<Product> FilterProducts(List<Product> products, string searchText)
+        {
+            if (string.IsNullOrWhiteSpace(searchText))
+            {
+                return products.Where(p => p.Stock > 0).ToList();
+            }
+
+            return products.Where(p =>
+                p.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase) &&
+                p.Stock > 0
+            ).ToList();
+        }
+    }
+}


### PR DESCRIPTION
## Functionaliteit
In een boodschappenlijst kan nu gezocht worden naar een product om toe te voegen.

## Wijzigingen
- Searchbar toegevoegd aan GroceryListItemsView.xaml
- Searchbar functionaliteit toegevoegd aan GroceryListItemsViewModel.cs
- Unit tests voor UC8 toegevoegd in TestProductSearch.cs

## Testing
- Manual test: Searchbar is aanwezig bij boodschappenlijsten
- Manual test: Bij invoeren productnaam worden producten correct gefilterd
- Manual test: Systeem toont een melding wanneer geen producten worden gevonden
- Manual test: Bij een leeg zoekveld worden alle producten getoond
- Manual test: Producten die toegevoegd worden aan de boodschappenlijst worden niet meer getoond
- Unit test: Alle tests slagen
- Pipeline tests: Alle tests slagen

## Use Case
- FR1: Er moet een zoekveld boven de productlijst staan naast de boodschappenlijst
- FR2: Het systeem moet een melding geven wanneer geen producten worden gevonden
- FR3: Wanneer de zoekwaarde leeg is, moeten alle producten getoond worden
- NFR1: De zoekbalk moet boven de productlijst zichtbaar zijn